### PR TITLE
Update to Jekyll 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'jekyll', '~>2.5'
-gem 'jekyll-git_metadata'
+gem 'jekyll', '~>3.1.1'

--- a/README.md
+++ b/README.md
@@ -14,8 +14,7 @@ Prereq
 ------
 
 ```
-$ sudo gem install jekyll
-$ sudo gem install jekyll-git_metadata
+$ gem install bundler && bundle install
 ```
 
 Setup

--- a/_defaults.yml
+++ b/_defaults.yml
@@ -24,7 +24,3 @@ destination: ./_site
 port: 4000
 host: 0.0.0.0
 safe: false
-
-# Extra Gems
-gems:
-  - jekyll-git_metadata

--- a/_includes/common_scripts.html
+++ b/_includes/common_scripts.html
@@ -1,12 +1,12 @@
 <!-- Distribution Scripts -->
-<script src="js/dist/jquery-2.2.0.min.js"></script>
-<script src="js/dist/jquery.cookie.js"></script>
-<script src="js/dist/bootstrap.min.js"></script>
+<script src="/js/dist/jquery-2.2.0.min.js"></script>
+<script src="/js/dist/jquery.cookie.js"></script>
+<script src="/js/dist/bootstrap.min.js"></script>
 
-<script src="js/dist/spin.min.js"></script>
-<script src="js/dist/ladda.min.js"></script>
-<script src="js/dist/ladda.jquery.min.js"></script>
+<script src="/js/dist/spin.min.js"></script>
+<script src="/js/dist/ladda.min.js"></script>
+<script src="/js/dist/ladda.jquery.min.js"></script>
 
 <!-- User-Defined Scripts -->
-<script src="js/common.js"></script>
-<script src="js/cog_api.js"></script>
+<script src="/js/common.js"></script>
+<script src="/js/cog_api.js"></script>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,8 +3,8 @@
     <div class="container">
       <p class="text-muted">
         COG-Web Beta (commit
-	    <a href="{{site.web_repo_url}}/commit/{{site.git.last_commit.long_sha}}"
-	       target="_blank">{{site.git.last_commit.short_sha}}</a>)
+	    <a href="{{site.web_repo_url}}/commit/{{site.data.long_hash}}"
+	       target="_blank">{{site.data.short_hash}}</a>)
 	    |
         Code and license on
         <a href="{{site.web_repo_url}}" target="_blank">GitHub</a>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -11,7 +11,7 @@
 	    |
         Built by
 	    <a href="http://www.andysayler.com" target="_blank">Andy Sayler</a> and
-        <a href="CONTRIBUTORS">Others</a>
+        <a href="/CONTRIBUTORS">Others</a>
 	    in Boulder, CO
       </p>
     </div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,10 +8,10 @@
 
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
 
-  <link href="css/dist/bootstrap.min.css" rel="stylesheet">
-  <link href="css/dist/bootstrap-theme.min.css" rel="stylesheet">
-  <link href="css/dist/ladda-themeless.min.css" rel="stylesheet">
-  <link href="css/cog-web.css" rel="stylesheet">
+  <link href="/css/dist/bootstrap.min.css" rel="stylesheet">
+  <link href="/css/dist/bootstrap-theme.min.css" rel="stylesheet">
+  <link href="/css/dist/ladda-themeless.min.css" rel="stylesheet">
+  <link href="/css/cog-web.css" rel="stylesheet">
 
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -9,13 +9,13 @@
           <span class="icon-bar"></span>
           <span class="icon-bar"></span>
         </button>
-        <a class="navbar-brand" href="#">{{ site.title }}</a>
+        <a class="navbar-brand" href="/">{{ site.title }}</a>
       </div>
       <div class="collapse navbar-collapse">
         <ul class="nav navbar-nav">
-          <li id="nav_submit"><a href="submit.html">Submit</a></li>
-          <li id="nav_about"><a href="about.html">About</a></li>
-          <li id="nav_help"><a href="help.html">Help</a></li>
+          <li id="nav_submit"><a href="/submit">Submit</a></li>
+          <li id="nav_about"><a href="/about">About</a></li>
+          <li id="nav_help"><a href="/help">Help</a></li>
         </ul>
         <ul class="nav navbar-nav navbar-right">
           <li>

--- a/_plugins/git-hash.rb
+++ b/_plugins/git-hash.rb
@@ -1,0 +1,11 @@
+module Jekyll
+  class GitHashGenerator < Generator
+    safe true
+
+    def generate(site)
+      sha1 = %x( git rev-parse HEAD ).strip
+      site.data['long_hash'] = sha1
+      site.data['short_hash'] = sha1[0..6]
+    end
+  end
+end

--- a/about.html
+++ b/about.html
@@ -23,7 +23,7 @@ ready_script: |
   <p class="lead">
     This front-end and the associated COG backend are both licensed
     under the AGPLv3, the full text of which can be found in the
-    associated <a href="COPYING">COPYING</a> file. The source code is
+    associated <a href="/COPYING">COPYING</a> file. The source code is
     available via
     <a href="{{site.web_repo_url}}" target="_blank">GitHub</a>.
     COG-Web uses the

--- a/js/common.js
+++ b/js/common.js
@@ -1,5 +1,5 @@
-var SUBMIT_URL = "submit.html";
-var LOGIN_URL = "login.html";
+var SUBMIT_URL = "/submit";
+var LOGIN_URL = "/login";
 var COOKIE_USER_PARAMS = { expires: 1, path: '/', secure: false }
 var COOKIE_USER_NAME = "cog_user"
 var COOKIE_TOKEN_PARAMS = { expires: 1, path: '/', secure: false }

--- a/login.html
+++ b/login.html
@@ -2,7 +2,7 @@
 layout: default
 
 extra_scripts:
-  - js/login.js
+  - /js/login.js
 
 ready_script: |
   token_redirect();

--- a/submit.html
+++ b/submit.html
@@ -2,7 +2,7 @@
 layout: default
 
 extra_scripts:
-  - js/submit.js
+  - /js/submit.js
 
 ready_script: |
   token_redirect();


### PR DESCRIPTION
This pull request accomplishes the following:

- remove unmaintained Git metadata plugin as dependency
- add a replacement for the above that has no dependencies
- update from Jekyll 2.5 to 3.1.1

Since Jekyll 3 now generates static pages by creating an `index.html` inside a directory, the following changes were also required:

- link extensions were dropped (e.g. `login.html` -> `login`)
- asset references were changed to be absolute