### PR TITLE
Set files to download as octet-stream

### DIFF
--- a/js/cog_api.js
+++ b/js/cog_api.js
@@ -115,6 +115,11 @@ function file_get(callback, callback_error, uuid) {
     get_auth(url, callback, callback_error);
 }
 
+function file_get_uri(uuid) {
+    var uri = "{{ site.cog_api_url }}/files/" + uuid + "/contents/";
+    return uri;
+}
+
 function file_get_contents(callback, callback_error, uuid) {
     var url = "{{ site.cog_api_url }}/files/" + uuid + "/contents/";
     get_auth(url, callback, callback_error);

--- a/js/cog_api.js
+++ b/js/cog_api.js
@@ -14,6 +14,26 @@ function get_auth(url, callback, callback_error) {
     });
 }
 
+function get_auth_binary(url, callback, callback_error) {
+    var token = $.cookie(COOKIE_TOKEN_NAME);
+
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', url, true);
+    xhr.responseType = 'blob';
+    xhr.setRequestHeader('Authorization', make_base_auth(token, ''));
+
+    xhr.onload = function() {
+      if (this.status === 200) {
+        var blob = this.response;
+        return callback(blob);
+      }
+
+      callback_error();
+    };
+
+    xhr.send();
+}
+
 function post_auth(url, callback, callback_error, data) {
     var token = $.cookie(COOKIE_TOKEN_NAME);
     $.ajax({
@@ -122,7 +142,7 @@ function file_get_uri(uuid) {
 
 function file_get_contents(callback, callback_error, uuid) {
     var url = "{{ site.cog_api_url }}/files/" + uuid + "/contents/";
-    get_auth(url, callback, callback_error);
+    get_auth_binary(url, callback, callback_error);
 }
 
 function my_assignment_submission_get(callback, callback_error, uuid) {

--- a/js/history.js
+++ b/js/history.js
@@ -39,7 +39,7 @@ function find_submissions(data, status) {
 		my_submission_run_get(iterate_runs, submit_error_callback, uuid);
 	});
 
-	function iterate_runs(data, status) {	
+	function iterate_runs(data, status) {
 		num_runs += data.runs.length;
 		num_subs++;
 
@@ -65,7 +65,7 @@ function add_runs(runs) {
 function get_run_info(data, status) {
 	var uuid = Object.keys(data)[0];
 	var run = data[uuid];
-	var new_row = {};		
+	var new_row = {};
 
 	// Get the time
 	var mseconds= run.modified_time;
@@ -131,14 +131,14 @@ function create_row(row) {
 function append_row(row) {
 	var sub = encodeURI("?uuid=" + row.suuid);
 	var run = encodeURI("?uuid=" + row.ruuid);
-	var sub_url = "/submission.html" + sub;
-	var run_url = "/run.html" + run;
+	var sub_url = "/submission/" + sub;
+	var run_url = "/run/" + run;
 
 	var see_sub = "<a href='" + sub_url + "'>Submission</a> or ";
 	var see_run = "<a href='" + run_url + "'>Run</a>";
 
-	var row_entry = "<tr><td>" + row.mtime.toLocaleString() + "</td><td>" + row.score + "</td><td>" 
-			+ row.retcode + "</td><td class='" + row.color + "'>" + row.status 
+	var row_entry = "<tr><td>" + row.mtime.toLocaleString() + "</td><td>" + row.score + "</td><td>"
+			+ row.retcode + "</td><td class='" + row.color + "'>" + row.status
 			+ "</td><td>" + see_sub + see_run + "</td></tr>";
 
 	if (row.test == tst_uuid) {
@@ -336,7 +336,7 @@ $("form#submitform").submit(function(event) {
     //submissions_get(display_history, submit_error_callback);
 
     // Clear table
-    $("#history_table tbody tr").remove(); 
+    $("#history_table tbody tr").remove();
 
     display_my_history();
 

--- a/js/submission.js
+++ b/js/submission.js
@@ -69,8 +69,7 @@ $('#files_table').delegate('.auth-dl', 'click', function(event) {
     var uuid = $(this).data('uuid');
     var name = $(this).data('name');
 
-    file_get_contents(function(data, status) {
-        var blob = new Blob([data], { type: 'octet/stream' });
+    file_get_contents(function(blob) {
         var url = window.URL.createObjectURL(blob);
 
         var a = document.createElement('a');

--- a/js/submission.js
+++ b/js/submission.js
@@ -1,89 +1,47 @@
 // Get retcode, score and status
 function show_files() {
-	var sub_uuid = getParameterByName('uuid');
-	var downloadable = getParameterByName('file');
+    var sub_uuid = getParameterByName('uuid');
+    $("span#sub_uuid").text(sub_uuid);
 
-	if (downloadable) {
-		initiate_download(downloadable);
-	}	
+    var find_files = function(data, status) {
+        var array_length = data.files.length;
+        var file_array = [];
 
-	$("span#sub_uuid").text(sub_uuid);
+        $.each(data.files, function(index, uuid) {
+            file_get(function(data, status) {
+                var f = {};
 
-	submission_get_files(find_files, submit_error_callback, sub_uuid);
+                var uuid = Object.keys(data)[0];
+                var file_name = data[uuid].name;
 
-	function find_files(data, status) {
-		var array_length = data.files.length;
-		var file_array = [];
+                f.name = file_name;
+                f.uuid = uuid;
 
-		$.each(data.files, function(index, uuid) {
-			file_get(append_files, submit_error_callback, uuid);
+                file_array.push(f);
 
-			function append_files(data, status) {
-				var f = {};
+                // Account for length of the array
+                if (file_array.length === array_length) {
+                    sort_files(file_array);
+                }
+            }, submit_error_callback, uuid);
+        });
+    };
 
-				var uuid = Object.keys(data)[0];
-
-				var file_name = data[uuid].name;
-
-				f.name = file_name;
-				f.uuid = uuid;
-
-				file_array.push(f);
-
-				// Account for length of the array
-				if(file_array.length == array_length) {
-					sort_files(file_array);
-				}
-			}
-		});
-	}
+    submission_get_files(find_files, submit_error_callback, sub_uuid);
 }
 
 function sort_files(file_array) {
     file_array.sort(function(x, y) {
-    	return x.name.localeCompare(y.name);
-	});
+        return x.name.localeCompare(y.name);
+    });
 
-	$.each(file_array, function(index, fle) {
-		var url_arr = window.location.href.split("&");
-		var fle_uri = encodeURI("&file=" + fle.uuid);
-		var url = url_arr[0] + fle_uri;
+    $.each(file_array, function(index, fle) {
+        var url = file_get_uri(fle.uuid);
+        $("#files_table").append("<tr><td>" + fle.name + '</td><td><a href="' + url + '">' + fle.uuid + "<a></td></tr>");
+    });
 
-		$("#files_table").append("<tr><td>" + fle.name + '</td><td><a href="' + url + '">' + fle.uuid + "<a></td></tr>");
-	});
-
-	console.log("Sorted Table");
+    console.log("Sorted Table");
 }
-
-function initiate_download(file_uuid) {
-    file_get(get_contents, submit_error_callback, file_uuid);
-
-    function get_contents(data, status) {
-        var filename = data[file_uuid].name;
-        file_get_contents(log_download, submit_error_callback, file_uuid);
-
-        function log_download(data, status) {
-            console.log("Downloading " + filename);
-            download(filename, data);
-        }
-    }
-}
-
-// Taken from http://stackoverflow.com/questions/3665115/create-a-file-in-memory-for-user-to-download-not-through-server
-function download(filename, text) {
-    var element = document.createElement('a');
-    element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
-    element.setAttribute('download', filename);
-
-    element.style.display = 'none';
-    document.body.appendChild(element);
-
-    element.click();
-
-    document.body.removeChild(element);
-    console.log("Download done");
-}
-
 
 // Taken from http://stackoverflow.com/questions/901115/how-can-i-get-query-string-values-in-javascript
 function getParameterByName(name, url) {

--- a/js/submission.js
+++ b/js/submission.js
@@ -80,6 +80,10 @@ $('#files_table').delegate('.auth-dl', 'click', function(event) {
 
         $(document.body).append(a);
         a.click();
-        window.URL.revokeObjectURL(url);
+
+        // permit time for deferred events to execute
+        setTimeout(function() {
+          window.URL.revokeObjectURL(url);
+        }, 100);
     }, submit_error_callback, uuid);
 });

--- a/js/submission.js
+++ b/js/submission.js
@@ -37,7 +37,7 @@ function sort_files(file_array) {
 
     $.each(file_array, function(index, fle) {
         var url = file_get_uri(fle.uuid);
-        $("#files_table").append("<tr><td>" + fle.name + '</td><td><a href="' + url + '">' + fle.uuid + "<a></td></tr>");
+        $("#files_table").append("<tr><td>" + fle.name + '</td><td><a class="auth-dl" href="' + url + '" data-name="' + fle.name + '" data-uuid="' + fle.uuid + '">' + fle.uuid + "<a></td></tr>");
     });
 
     console.log("Sorted Table");
@@ -62,3 +62,24 @@ function submit_error_callback(xhr, status, error) {
     // Log Error
     console.log("Status: " + status, ", Error: " + error);
 }
+
+$('#files_table').delegate('.auth-dl', 'click', function(event) {
+    event.preventDefault();
+
+    var uuid = $(this).data('uuid');
+    var name = $(this).data('name');
+
+    file_get_contents(function(data, status) {
+        var blob = new Blob([data], { type: 'octet/stream' });
+        var url = window.URL.createObjectURL(blob);
+
+        var a = document.createElement('a');
+        a.style = 'display: none';
+        a.href = url;
+        a.download = name;
+
+        $(document.body).append(a);
+        a.click();
+        window.URL.revokeObjectURL(url);
+    }, submit_error_callback, uuid);
+});


### PR DESCRIPTION
This pull request addresses issue #26 by removing the AJAX download mechanism in favor of directly downloading the file from a COG server endpoint. This removes any client-side requirement for a MIME type definition (which would have to be `application/octet-stream` unless the COG server stores file metadata).