### PR TITLE
Clear loading text placeholders when loading assignments. Fixes #34.

### DIFF
--- a/js/submit.js
+++ b/js/submit.js
@@ -20,8 +20,13 @@
       // inform the user if no assignments can be currently submitted
       if (!assignments.length) {
         var option = $('<option>').text('No Assignments Accepting Submissions');
-        // only on initial load, no empty required
-        select.append(option);
+        // clear out loading text and add single option
+        select.empty().append(option);
+
+        // repeat with test selector
+        var toption = $('<option>').text('No Tests Available');
+        $('select#test').empty().append(toption);
+
         return;
       }
 


### PR DESCRIPTION
This pull request empties selectors should they be populated at a later time so that the option that is to be added will be forced to be shown. Please let me know if it doesn't work or causes other problems.
